### PR TITLE
ci: apt-get update before install-deps

### DIFF
--- a/docker/ceph-plugin/entrypoint.sh
+++ b/docker/ceph-plugin/entrypoint.sh
@@ -9,6 +9,7 @@ pushd /ceph
 git fetch origin
 git checkout -b build origin/zlog/master-pb
 
+apt-get update
 ./install-deps.sh
 ./do_cmake.sh
 


### PR DESCRIPTION
fixes stuff like

Err:39 http://archive.ubuntu.com/ubuntu xenial-security/main amd64
libxml2 amd64 2.9.3+dfsg1-1ubuntu0.1
404  Not Found [IP: 91.189.88.152 80]
E: Failed to fetch
http://archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2_2.9.3+dfsg1-1ubuntu0.1_amd64.deb
404  Not Found [IP: 91.189.88.152 80]

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>