### PR TITLE
kvs: use unique root id

### DIFF
--- a/src/kvstore/db_impl.h
+++ b/src/kvstore/db_impl.h
@@ -52,7 +52,7 @@ class DBImpl : public DB {
   friend class NodePtr;
   friend class IteratorTraceApplier;
 
-  void write_dot_recursive(std::ostream& out, uint64_t rid,
+  void write_dot_recursive(std::ostream& out, int64_t rid,
       SharedNodeRef node, uint64_t& nullcount, bool scoped);
   void write_dot_null(std::ostream& out, SharedNodeRef node, uint64_t& nullcount);
   void write_dot_node(std::ostream& out, SharedNodeRef parent,
@@ -95,17 +95,13 @@ class DBImpl : public DB {
   NodeCache cache_;
   bool stop_;
 
+  // counter to generate a unique root id for in-flight transactions.
+  // committed transactions use their position in the log as a root id, and
+  // this counter is always negative to produce non-conflicting values.
+  int64_t root_id_;
+
   // tree from last tranascation
   NodePtr root_;
-
-  // TODO: generate a new unique root_id_ for each transaction. this id is
-  // added to new nodes generated during txn processing to identify nodes in
-  // an intention from nodes outside the intention for the given txn. there is
-  // currently a bug in the way this is handled: during node deserialization
-  // in node_cache the csn is used as the rid value, but there is no mechanism
-  // to prevent new transactions from being assigned a root_id that would
-  // conflict with a csn value.
-  static uint64_t root_id_;
 
   // transaction handling
   TransactionImpl *cur_txn_;

--- a/src/kvstore/node.h
+++ b/src/kvstore/node.h
@@ -200,8 +200,15 @@ class Node {
     std::swap(red_, other->red_);
   }
 
-  inline uint64_t rid() const {
+  inline int64_t rid() const {
     return rid_;
+  }
+
+  inline void set_rid(int64_t rid) {
+    assert(!read_only());
+    assert(rid_ < 0);
+    assert(rid >= 0);
+    rid_ = rid;
   }
 
   // TODO: return const reference?
@@ -229,7 +236,7 @@ class Node {
   std::string key_;
   std::string val_;
   bool red_;
-  uint64_t rid_;
+  int64_t rid_;
   bool read_only_;
 };
 

--- a/src/kvstore/transaction_impl.cc
+++ b/src/kvstore/transaction_impl.cc
@@ -571,4 +571,9 @@ void TransactionImpl::SetDeltaPosition(std::vector<SharedNodeRef>& delta,
       nn->right.set_csn(pos);
     }
   }
+
+  // set the rid of these nodes to the log position where they are stored.
+  for (auto nn : delta) {
+    nn->set_rid(pos);
+  }
 }

--- a/src/kvstore/transaction_impl.h
+++ b/src/kvstore/transaction_impl.h
@@ -13,12 +13,15 @@ class DBImpl;
  */
 class TransactionImpl : public Transaction {
  public:
-  TransactionImpl(DBImpl *db, NodePtr root, uint64_t rid) :
-    db_(db), src_root_(root), root_(nullptr), rid_(rid),
+  TransactionImpl(DBImpl *db, NodePtr root, int64_t rid) :
+    db_(db),
+    src_root_(root),
+    root_(nullptr),
+    rid_(rid),
     committed_(false),
     completed_(false)
   {
-    // TODO: reserve trace as average height
+    assert(rid_ < 0);
   }
 
   virtual void Put(const Slice& key, const Slice& value) override;
@@ -68,7 +71,7 @@ class TransactionImpl : public Transaction {
 
   // transaction after image
   SharedNodeRef root_;
-  const uint64_t rid_;
+  const int64_t rid_;
 
   std::mutex lock_;
 


### PR DESCRIPTION
this uses a unique negative value for the root-id of new transactions.
before a node is integrated into the node cache (when the txn commits,
or a node is retreived from the log) the log position (non-negative) is
used as the root id.

fixes #136

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>