### PR TITLE
kvs: fix member initialization race

### DIFF
--- a/src/kvstore/db_impl.h
+++ b/src/kvstore/db_impl.h
@@ -107,10 +107,18 @@ class DBImpl : public DB {
 
   // transaction handling
   TransactionImpl *cur_txn_;
-  std::thread txn_finisher_;
   void TransactionFinisher();
   std::condition_variable txn_finisher_cond_;
   std::condition_variable cur_txn_cond_;
+
+  // from the spec "Then, nonstatic data members shall be initialized in the
+  // order they were declared in the class definition (again regardless of the
+  // order of the mem-initializers)."
+  //
+  // since the thread will immediately start interacting with this class,
+  // everything needs to be initialized. in particular the condition
+  // variables.
+  std::thread txn_finisher_;
 };
 
 #endif


### PR DESCRIPTION
the txn finisher thread needs to be started after the condition variable
it uses is initialized, otherwise there is a race that the thread
sometimes wins and accesses the unitialized cond variable.

from the c++ spec: the non static members are initialized in
declaration order, independent of mem-initializer list order.

fixes: #142

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>